### PR TITLE
 Improve event deduplication and rule evaluation, add daemon status logging and new CLI commands.

### DIFF
--- a/eventwatcher/cli.py
+++ b/eventwatcher/cli.py
@@ -9,6 +9,7 @@ from eventwatcher import config
 from eventwatcher import db
 from eventwatcher import monitor
 from eventwatcher import daemon as daemon_module
+from eventwatcher import rule_helpers
 import psutil
 from rich.console import Console
 from rich.table import Table

--- a/eventwatcher/cli.py
+++ b/eventwatcher/cli.py
@@ -5,10 +5,15 @@ import threading
 import json
 import click
 import sqlite3
-from . import config
-from . import db
-from . import monitor
-from . import daemon as daemon_module
+from eventwatcher import config
+from eventwatcher import db
+from eventwatcher import monitor
+from eventwatcher import daemon as daemon_module
+import psutil
+from rich.console import Console
+from rich.table import Table
+import csv
+import io
 
 DEFAULT_PID_FILENAME = "eventwatcher.pid"
 
@@ -22,15 +27,13 @@ def main(ctx, config_path, debug):
     """
     try:
         cfg = config.load_config(config_path)
-        # If --debug is passed, override logging level to DEBUG.
         if debug:
             cfg.setdefault("logging", {})["level"] = "DEBUG"
-        # Store the config file path for later use.
         cfg["__config_path__"] = config_path
     except Exception as e:
         click.echo(f"Error loading configuration: {e}")
         ctx.abort()
-    ctx.obj = {"config": cfg, "config_path": config_path}
+    ctx.obj = {"config": cfg, "config_path": config_path, "debug": debug}
 
 def get_log_dir(cfg, config_path):
     config_dir = os.path.dirname(cfg.get("config_path", config_path) or "./config.toml")
@@ -70,7 +73,6 @@ def monitor_once(ctx):
     config_dir = os.path.dirname(ctx.obj.get("config_path") or "./config.toml")
     db_path = os.path.join(config_dir, cfg.get("database", {}).get("db_name", "eventwatcher.db"))
     log_dir = get_log_dir(cfg, ctx.obj.get("config_path"))
-    # Load watch groups configuration from YAML.
     watch_groups_config_path = cfg.get("watch_groups", {}).get("configs_dir", "watch_groups.yaml")
     try:
         watch_groups = config.load_watch_groups_configs(watch_groups_config_path)
@@ -99,7 +101,6 @@ def start(ctx, foreground):
     db_path = os.path.join(config_dir, cfg.get("database", {}).get("db_name", "eventwatcher.db"))
     log_dir = get_log_dir(cfg, ctx.obj.get("config_path"))
     pid_file = get_pid_file(log_dir)
-    # Load watch groups configuration from YAML.
     watch_groups_config_path = cfg.get("watch_groups", {}).get("configs_dir", "watch_groups.yaml")
     try:
         watch_groups_data = config.load_watch_groups_configs(watch_groups_config_path)
@@ -158,27 +159,56 @@ def stop(ctx):
 def status(ctx):
     """
     Check the status of the EventWatcher daemon.
+    Displays process info (memory, CPU, threads, start time) and watch group details.
+    Also logs this info to daemon.log.
     """
     cfg = ctx.obj.get("config")
     log_dir = get_log_dir(cfg, ctx.obj.get("config_path"))
     pid_file = get_pid_file(log_dir)
+    console = Console()
+
     if not os.path.exists(pid_file):
         click.echo("Daemon is not running (pid file not found).")
         return
+
     with open(pid_file, 'r') as f:
         pid = int(f.read().strip())
     try:
-        os.kill(pid, 0)
-        click.echo(f"Daemon is running (pid {pid}).")
-    except Exception:
-        click.echo("Daemon is not running, but pid file exists.")
+        proc = psutil.Process(pid)
+    except psutil.NoSuchProcess:
+        click.echo("Daemon process not found.")
+        return
 
-@main.command()
+    status_table = Table(title="EventWatcher Daemon Status")
+    status_table.add_column("Property", style="cyan")
+    status_table.add_column("Value", style="magenta")
+    status_table.add_row("PID", str(proc.pid))
+    status_table.add_row("CPU %", f"{proc.cpu_percent(interval=0.1)}")
+    status_table.add_row("Memory %", f"{proc.memory_percent():.2f}")
+    status_table.add_row("Memory RSS", str(proc.memory_info().rss))
+    status_table.add_row("Threads", str(proc.num_threads()))
+    status_table.add_row("Start Time", time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(proc.create_time())))
+
+    # For watch groups info, load the watch groups configuration.
+    watch_groups_config_path = cfg.get("watch_groups", {}).get("configs_dir", "watch_groups.yaml")
+    try:
+        watch_groups_data = config.load_watch_groups_configs(watch_groups_config_path)
+        groups = watch_groups_data.get("watch_groups", [])
+        status_table.add_row("Watch Groups Count", str(len(groups)))
+        group_names = ", ".join([g.get("name", "Unnamed") for g in groups])
+        status_table.add_row("Watch Group Names", group_names)
+    except Exception as e:
+        status_table.add_row("Watch Groups", f"Error loading: {e}")
+
+    console.print(status_table)
+
+@main.command(name="show-events")
 @click.option("--watch-group", "-w", default=None, help="Filter by watch group name.")
+@click.option("--format", "-f", "out_format", default="tabulate", type=click.Choice(["tabulate", "json", "csv", "raw"], case_sensitive=False), help="Output format.")
 @click.pass_context
-def search_db(ctx, watch_group):
+def show_events(ctx, watch_group, out_format):
     """
-    Search events in the database.
+    Show events stored in the database with various output formats.
     """
     cfg = ctx.obj.get("config")
     config_dir = os.path.dirname(ctx.obj.get("config_path") or "./config.toml")
@@ -190,67 +220,110 @@ def search_db(ctx, watch_group):
     else:
         cur.execute("SELECT * FROM events")
     rows = cur.fetchall()
-    if rows:
-        click.echo("Events:")
-        for row in rows:
-            click.echo(row)
-    else:
-        click.echo("No events found.")
     conn.close()
 
+    if out_format.lower() == "json":
+        click.echo(json.dumps([dict(row) for row in rows], indent=2))
+    elif out_format.lower() == "csv":
+        if rows:
+            output = io.StringIO()
+            writer = csv.writer(output)
+            writer.writerow(rows[0].keys())
+            for row in rows:
+                writer.writerow(list(row))
+            click.echo(output.getvalue())
+        else:
+            click.echo("No events found.")
+    elif out_format.lower() == "raw":
+        click.echo(rows)
+    else:
+        # Default: tabulate using rich table
+        table = Table(title="EventWatcher Events")
+        if rows:
+            for col in rows[0].keys():
+                table.add_column(col)
+            for row in rows:
+                table.add_row(*[str(val) for val in row])
+            Console().print(table)
+        else:
+            click.echo("No events found.")
+
 @main.command()
-@click.option("--term", "-t", default="", help="Search term for log files.")
+@click.argument("sql_query", nargs=-1)
 @click.pass_context
-def search_logs(ctx, term):
+def query(ctx, sql_query):
     """
-    Search through log files in the logs directory.
+    Execute an arbitrary SQL query against the EventWatcher database.
+    Example:
+      eventwatcher query "SELECT * FROM events LIMIT 5"
     """
     cfg = ctx.obj.get("config")
-    log_dir = get_log_dir(cfg, ctx.obj.get("config_path"))
-    if not os.path.isdir(log_dir):
-        click.echo("Logs directory not found.")
-        return
-    for root, _, files in os.walk(log_dir):
-        for file in files:
-            if file.endswith(".log"):
-                file_path = os.path.join(root, file)
-                with open(file_path, "r") as f:
-                    contents = f.read()
-                    if term in contents:
-                        click.echo(f"Found in {file_path}:")
-                        click.echo(contents)
-                        click.echo("-" * 40)
+    config_dir = os.path.dirname(ctx.obj.get("config_path") or "./config.toml")
+    db_path = os.path.join(config_dir, cfg.get("database", {}).get("db_name", "eventwatcher.db"))
+    query_str = " ".join(sql_query)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    try:
+        cur.execute(query_str)
+        rows = cur.fetchall()
+        if rows:
+            table = Table(title="Query Results")
+            for col in rows[0].keys():
+                table.add_column(col)
+            for row in rows:
+                table.add_row(*[str(val) for val in row])
+            Console().print(table)
+        else:
+            click.echo("No results found.")
+    except Exception as e:
+        click.echo(f"Error executing query: {e}")
+    finally:
+        conn.close()
 
 @main.command()
 @click.pass_context
-def restart(ctx):
+def info(ctx):
     """
-    Restart the EventWatcher daemon.
-    """
-    ctx.invoke(stop)
-    time.sleep(1)
-    ctx.invoke(start)
-
-@main.command()
-@click.pass_context
-def show_db(ctx):
-    """
-    Show events stored in the database.
+    Show available database tables/columns and available rule helper functions.
     """
     cfg = ctx.obj.get("config")
     config_dir = os.path.dirname(ctx.obj.get("config_path") or "./config.toml")
     db_path = os.path.join(config_dir, cfg.get("database", {}).get("db_name", "eventwatcher.db"))
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
-    cur.execute("SELECT * FROM events")
-    rows = cur.fetchall()
-    if rows:
-        click.echo("Events:")
-        for row in rows:
-            click.echo(row)
-    else:
-        click.echo("No events found.")
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    tables = [row[0] for row in cur.fetchall()]
     conn.close()
+
+    console = Console()
+    table = Table(title="Database Tables & Columns")
+    table.add_column("Table Name", style="cyan")
+    table.add_column("Columns", style="magenta")
+    for t in tables:
+        conn = sqlite3.connect(db_path)
+        cur = conn.cursor()
+        cur.execute(f"PRAGMA table_info({t})")
+        cols = [row[1] for row in cur.fetchall()]
+        conn.close()
+        table.add_row(t, ", ".join(cols))
+    console.print(table)
+
+    # List available rule helper functions.
+    console.print("\n[bold]Available Rule Helper Functions:[/bold]")
+    available_funcs = {
+        "aggregate_metric": rule_helpers.aggregate_metric,
+        "get_previous_metric": rule_helpers.get_previous_metric,
+        # plus safe builtins
+        "min": min,
+        "max": max,
+        "any": any,
+        "all": all,
+        "sum": sum,
+        "len": len,
+    }
+    for func_name in available_funcs:
+        console.print(f" - {func_name}")
 
 if __name__ == "__main__":
     main()

--- a/eventwatcher/cli.py
+++ b/eventwatcher/cli.py
@@ -15,6 +15,7 @@ from rich.console import Console
 from rich.table import Table
 import csv
 import io
+import sys
 
 DEFAULT_PID_FILENAME = "eventwatcher.pid"
 
@@ -221,6 +222,7 @@ def show_events(ctx, watch_group, out_format):
     else:
         cur.execute("SELECT * FROM events")
     rows = cur.fetchall()
+    columns = [column[0] for column in cur.description]
     conn.close()
 
     if out_format.lower() == "json":
@@ -241,7 +243,7 @@ def show_events(ctx, watch_group, out_format):
         # Default: tabulate using rich table
         table = Table(title="EventWatcher Events")
         if rows:
-            for col in rows[0].keys():
+            for col in columns:
                 table.add_column(col)
             for row in rows:
                 table.add_row(*[str(val) for val in row])

--- a/eventwatcher/cli.py
+++ b/eventwatcher/cli.py
@@ -231,7 +231,7 @@ def show_events(ctx, watch_group, out_format):
         if rows:
             output = io.StringIO()
             writer = csv.writer(output)
-            writer.writerow(rows[0].keys())
+            writer.writerow(columns)
             for row in rows:
                 writer.writerow(list(row))
             click.echo(output.getvalue())

--- a/eventwatcher/daemon.py
+++ b/eventwatcher/daemon.py
@@ -4,40 +4,23 @@ import threading
 import time
 import os
 import logging
-from . import monitor
-from . import logger
+from eventwatcher import monitor
+from eventwatcher import logger
 import eventwatcher.config as config_module
 
 def run_daemon(watch_groups, db_path, pid_file, config):
     """
     Run the monitoring service as a daemon with auto-reload functionality.
-
-    The daemon monitors changes to the main configuration file and the watch groups configuration.
-    If any changes are detected, the daemon will stop current monitors, reload the configuration,
-    and restart the monitors.
-
-    Args:
-        watch_groups (list): List of watch group configurations.
-        db_path (str): Path to the SQLite database.
-        pid_file (str): Path to the PID file.
-        config (dict): The configuration settings. It should include the key '__config_path__'
-                       which is the path to the main configuration file.
     """
-    # Get the config file path and watch groups config path from the config dictionary.
-    # (The __config_path__ key should be set in cli.py when loading the config.)
     config_file_path = config.get("__config_path__", "./config.toml")
     watch_groups_config_path = config.get("watch_groups", {}).get("configs_dir", "watch_groups.yaml")
 
     # Set up logging for the daemon.
     log_dir = os.path.join(".", config.get("logging", {}).get("log_dir", "logs"))
     numeric_level = getattr(logging, config.get("logging", {}).get("level", "INFO").upper(), logging.INFO)
-    root_logger = logger.setup_logger("EventWatcherDaemon", log_dir, "daemon.log", level=numeric_level)
+    root_logger = logger.setup_logger("EventWatcherDaemon", log_dir, "daemon.log", level=numeric_level, console=True)
 
     def run_monitors():
-        """
-        Start monitor threads for each watch group and poll for configuration changes.
-        When a change is detected, all monitors are stopped.
-        """
         monitors = []
         threads = []
         for group in watch_groups:
@@ -53,7 +36,6 @@ def run_daemon(watch_groups, db_path, pid_file, config):
             t.start()
             threads.append(t)
 
-        # Record initial modification times.
         try:
             config_mtime = os.path.getmtime(config_file_path)
         except Exception as e:
@@ -61,7 +43,6 @@ def run_daemon(watch_groups, db_path, pid_file, config):
             config_mtime = None
 
         if os.path.isdir(watch_groups_config_path):
-            # For a directory, build a dict mapping file path to its modification time.
             watch_groups_mtimes = {}
             for filename in os.listdir(watch_groups_config_path):
                 if filename.endswith(('.yaml', '.yml')):
@@ -77,10 +58,8 @@ def run_daemon(watch_groups, db_path, pid_file, config):
                 root_logger.error(f"Error getting modification time for watch groups config file: {e}")
                 watch_groups_mtimes = None
 
-        # Poll for configuration changes every 10 seconds.
         while True:
             reload_needed = False
-            # Check main config file.
             try:
                 new_config_mtime = os.path.getmtime(config_file_path)
                 if config_mtime and new_config_mtime != config_mtime:
@@ -88,7 +67,6 @@ def run_daemon(watch_groups, db_path, pid_file, config):
             except Exception as e:
                 root_logger.error(f"Error checking config file mtime: {e}")
 
-            # Check watch groups config (either directory or single file).
             if os.path.isdir(watch_groups_config_path):
                 for filename in os.listdir(watch_groups_config_path):
                     if filename.endswith(('.yaml', '.yml')):
@@ -112,39 +90,32 @@ def run_daemon(watch_groups, db_path, pid_file, config):
                 root_logger.info("Configuration change detected. Restarting monitors.")
                 break
 
-            # Also check that all monitor threads are alive.
             for t in threads:
                 if not t.is_alive():
                     root_logger.error("A monitor thread has stopped unexpectedly.")
             time.sleep(10)
 
-        # Stop all monitors.
+            # End of the run_monitors loop.
         for m in monitors:
             m.stop()
         for t in threads:
             t.join()
 
-    # Use PIDLockFile to manage the PID file.
     pidfile_obj = PIDLockFile(pid_file)
     with daemon.DaemonContext(pidfile=pidfile_obj):
         root_logger.info("Daemon started with auto-reload enabled.")
-        # Run in a loop: each iteration runs the monitors until a config change is detected.
         while True:
             run_monitors()
-            # After monitors have stopped, reload configuration.
             try:
                 new_config = config_module.load_config(config_file_path)
-                # Store the config file path in the new config dictionary.
                 new_config["__config_path__"] = config_file_path
                 new_watch_groups_data = config_module.load_watch_groups_configs(
-                    new_config.get("watch_groups", {}).get("watch_groups_config", "watch_groups.yaml")                )
+                    new_config.get("watch_groups", {}).get("watch_groups_config", "watch_groups.yaml")
+                )
                 new_watch_groups = new_watch_groups_data.get("watch_groups", [])
                 root_logger.info("Configuration reloaded. Restarting monitors.")
-                # Update variables for the next loop iteration.
                 watch_groups = new_watch_groups
                 config = new_config
-                # Optionally, update db_path or log_dir if they have changed.
             except Exception as e:
                 root_logger.error(f"Error reloading configuration: {e}")
-                # If there is an error, wait a bit before trying again.
                 time.sleep(10)

--- a/eventwatcher/db.py
+++ b/eventwatcher/db.py
@@ -6,12 +6,6 @@ import uuid
 def get_db_connection(db_path):
     """
     Get a SQLite3 connection.
-
-    Args:
-        db_path (str): The path to the database file.
-
-    Returns:
-        sqlite3.Connection: A database connection.
     """
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
@@ -20,13 +14,13 @@ def get_db_connection(db_path):
 def init_db(db_path):
     """
     Initialize the SQLite database with the required tables.
-
-    This function creates the 'events' and 'samples' tables if they do not exist.
+    Creates the 'events' table and the 'samples' table (formerly exploded_samples).
     """
     os.makedirs(os.path.dirname(db_path), exist_ok=True)
     conn = get_db_connection(db_path)
     cur = conn.cursor()
 
+    # Create events table (storing only key information)
     cur.execute('''
         CREATE TABLE IF NOT EXISTS events (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -36,33 +30,15 @@ def init_db(db_path):
             event_type TEXT,
             severity TEXT,
             affected_files TEXT,
-            timestamp_diff TEXT,
-            sample_data TEXT,
+            sample_epoch INTEGER,
             timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
             UNIQUE(event_uid)
         )
     ''')
 
+    # Create samples table (per-file detailed records)
     cur.execute('''
         CREATE TABLE IF NOT EXISTS samples (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            watch_group TEXT NOT NULL,
-            sample TEXT NOT NULL,
-            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
-        )
-    ''')
-
-    conn.commit()
-    conn.close()
-
-def init_exploded_samples(db_path):
-    """
-    Initialize the 'exploded_samples' table for storing individual file metrics.
-    """
-    conn = get_db_connection(db_path)
-    cur = conn.cursor()
-    cur.execute('''
-        CREATE TABLE IF NOT EXISTS exploded_samples (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             watch_group TEXT NOT NULL,
             sample_epoch INTEGER NOT NULL,
@@ -75,30 +51,22 @@ def init_exploded_samples(db_path):
             pattern_found BOOLEAN
         )
     ''')
+
     conn.commit()
     conn.close()
 
-def insert_event(db_path, watch_group, event, sample_data,
-                 event_type=None, severity=None, affected_files=None, timestamp_diff=None):
+def insert_event(db_path, watch_group, event, sample_epoch,
+                 event_type=None, severity=None, affected_files=None):
     """
-    Insert an event record into the database with structured metadata.
-
-    Args:
-        db_path (str): Path to the database.
-        watch_group (str): Name of the watch group.
-        event (str): Event name/description.
-        sample_data (dict): The sample data triggering the event.
-        event_type (str): Type of event (e.g., created, modified, deleted, pattern_match).
-        severity (str): Severity level (e.g., INFO, WARNING, CRITICAL).
-        affected_files (list): List of file paths that triggered the event.
-        timestamp_diff (dict): Differences in timestamp (e.g., modification delta) for affected files.
+    Insert an event record into the events table.
+    Instead of storing raw sample data, we store the sample_epoch and affected files.
     """
     conn = get_db_connection(db_path)
     cur = conn.cursor()
     event_uid = str(uuid.uuid4())
     cur.execute('''
-        INSERT INTO events (event_uid, watch_group, event, event_type, severity, affected_files, timestamp_diff, sample_data)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO events (event_uid, watch_group, event, event_type, severity, affected_files, sample_epoch)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
     ''', (
         event_uid,
         watch_group,
@@ -106,45 +74,19 @@ def insert_event(db_path, watch_group, event, sample_data,
         event_type,
         severity,
         json.dumps(affected_files),
-        json.dumps(timestamp_diff),
-        json.dumps(sample_data)
+        sample_epoch
     ))
     conn.commit()
     conn.close()
 
-def insert_sample(db_path, watch_group, sample):
+def insert_sample_record(db_path, watch_group, sample_epoch, file_path, file_data):
     """
-    Insert a sample record into the database.
-
-    Args:
-        db_path (str): Path to the database.
-        watch_group (str): Name of the watch group.
-        sample (dict): The collected sample data.
+    Insert an individual file's data into the samples table.
     """
     conn = get_db_connection(db_path)
     cur = conn.cursor()
     cur.execute('''
-        INSERT INTO samples (watch_group, sample)
-        VALUES (?, ?)
-    ''', (watch_group, json.dumps(sample)))
-    conn.commit()
-    conn.close()
-
-def insert_exploded_sample(db_path, watch_group, sample_epoch, file_path, file_data):
-    """
-    Insert an individual file's data into the exploded_samples table.
-
-    Args:
-        db_path (str): Path to the database.
-        watch_group (str): Name of the watch group.
-        sample_epoch (int): The epoch timestamp representing this sample cycle.
-        file_path (str): The file or directory path.
-        file_data (dict): The metrics collected for the file.
-    """
-    conn = get_db_connection(db_path)
-    cur = conn.cursor()
-    cur.execute('''
-        INSERT INTO exploded_samples (
+        INSERT INTO samples (
             watch_group, sample_epoch, file_path, size, last_modified,
             creation_time, md5, sha256, pattern_found
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -162,22 +104,43 @@ def insert_exploded_sample(db_path, watch_group, sample_epoch, file_path, file_d
     conn.commit()
     conn.close()
 
-def get_last_sample(db_path, watch_group):
+def get_last_event_for_rule(db_path, watch_group, rule_name, file_path):
     """
-    Retrieve the most recent sample for a given watch group.
-
-    Args:
-        db_path (str): Path to the database.
-        watch_group (str): Name of the watch group.
-
-    Returns:
-        tuple: (sample (dict), timestamp (str)) if found; otherwise (None, None)
+    Retrieve the most recent event for a given watch_group, rule (event description), and file.
+    Returns a dict with event data or None if not found.
     """
     conn = get_db_connection(db_path)
     cur = conn.cursor()
-    cur.execute("SELECT sample, timestamp FROM samples WHERE watch_group = ? ORDER BY timestamp DESC LIMIT 1", (watch_group,))
+    query = '''
+        SELECT * FROM events
+        WHERE watch_group = ? AND event = ?
+        ORDER BY sample_epoch DESC LIMIT 1
+    '''
+    cur.execute(query, (watch_group, rule_name))
     row = cur.fetchone()
     conn.close()
     if row:
-        return json.loads(row[0]), row[1]
-    return None, None
+        # Check if the file_path is in affected_files
+        affected_files = json.loads(row['affected_files'])
+        if file_path in affected_files:
+            return dict(row)
+    return None
+
+def get_sample_record(db_path, watch_group, sample_epoch, file_path):
+    """
+    Retrieve the sample record for a given watch_group, sample_epoch, and file_path.
+    Returns a dict with sample data or None if not found.
+    """
+    conn = get_db_connection(db_path)
+    cur = conn.cursor()
+    query = '''
+        SELECT * FROM samples
+        WHERE watch_group = ? AND sample_epoch = ? AND file_path = ?
+        LIMIT 1
+    '''
+    cur.execute(query, (watch_group, sample_epoch, file_path))
+    row = cur.fetchone()
+    conn.close()
+    if row:
+        return dict(row)
+    return None

--- a/eventwatcher/db.py
+++ b/eventwatcher/db.py
@@ -44,6 +44,9 @@ def init_db(db_path):
             sample_epoch INTEGER NOT NULL,
             file_path TEXT NOT NULL,
             size INTEGER,
+            user_id INTEGER,
+            group_id INTEGER,
+            mode INTEGER,
             last_modified REAL,
             creation_time REAL,
             md5 TEXT,
@@ -86,14 +89,18 @@ def insert_sample_record(db_path, watch_group, sample_epoch, file_path, file_dat
     cur = conn.cursor()
     cur.execute('''
         INSERT INTO samples (
-            watch_group, sample_epoch, file_path, size, last_modified,
+            watch_group, sample_epoch, file_path, size,
+            user_id, group_id, mode, last_modified,
             creation_time, md5, sha256, pattern_found
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ''', (
         watch_group,
         sample_epoch,
         file_path,
         file_data.get("size"),
+        file_data.get("user_id"),
+        file_data.get("group_id"),
+        file_data.get("mode"),
         file_data.get("last_modified"),
         file_data.get("creation_time"),
         file_data.get("md5"),

--- a/eventwatcher/logger.py
+++ b/eventwatcher/logger.py
@@ -3,32 +3,40 @@ import os
 
 def setup_logger(name, log_dir, log_filename, level=logging.INFO, console=True):
     """
-    Set up and return a logger with file and optional console handlers.
+    Set up and return a logger with file and (optionally) console handlers.
 
     Args:
-        name (str): Name of the logger.
-        log_dir (str): Directory where log file will be stored.
+        name (str): The logger name.
+        log_dir (str): Directory where the log file will be stored.
         log_filename (str): Log file name.
         level (int): Logging level.
         console (bool): Whether to add a console handler.
 
     Returns:
-        logging.Logger: Configured logger.
+        logging.Logger: The configured logger.
     """
     if not os.path.exists(log_dir):
         os.makedirs(log_dir, exist_ok=True)
+
     logger = logging.getLogger(name)
     logger.setLevel(level)
+
+    # Clear out any existing handlers.
+    logger.handlers = []
+
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
-    # File handler
+    # File handler with the specified level.
     file_handler = logging.FileHandler(os.path.join(log_dir, log_filename))
+    file_handler.setLevel(level)
     file_handler.setFormatter(formatter)
     logger.addHandler(file_handler)
 
-    # Console handler
+    # Optional console handler.
     if console:
         console_handler = logging.StreamHandler()
+        console_handler.setLevel(level)
         console_handler.setFormatter(formatter)
         logger.addHandler(console_handler)
+
     return logger

--- a/eventwatcher/monitor.py
+++ b/eventwatcher/monitor.py
@@ -48,6 +48,9 @@ def collect_sample(watch_group, log_dir):
                 metrics["creation_time"] = stat.st_ctime
                 metrics["md5"] = compute_file_md5(path)
                 metrics["sha256"] = compute_file_sha256(path)
+                metrics["user_id"] = stat.st_uid
+                metrics["group_id"] = stat.st_gid
+                metrics["mode"] =  oct(stat.st_mode & 0o777)
                 if pattern:
                     with open(path, "r", errors="ignore") as f:
                         content = f.read()

--- a/eventwatcher/monitor.py
+++ b/eventwatcher/monitor.py
@@ -1,347 +1,155 @@
 import os
-import hashlib
-import pwd
-import grp
 import time
-import glob
+import hashlib
 import logging
-from . import db
-from . import logger
-from eventwatcher.rule_helpers import aggregate_metric, get_previous_metric
+from eventwatcher import db, rules, rule_helpers
 
-
-
-def collect_dir_files_info(dir_path, max_depth=None, pattern=None):
-    """
-    Recursively traverse a directory up to max_depth and collect file metrics individually.
-
-    Args:
-        dir_path (str): Directory to traverse.
-        max_depth (int, optional): Maximum depth to traverse.
-        pattern (str, optional): Pattern to search for in files.
-
-    Returns:
-        dict: Mapping file paths to their collected information.
-    """
-    files_info = {}
-
-    def _traverse(current_path, current_depth):
-        if max_depth is not None and current_depth > max_depth:
-            return
-        try:
-            with os.scandir(current_path) as it:
-                for entry in it:
-                    full_path = entry.path
-                    if entry.is_file():
-                        files_info[full_path] = collect_file_info(full_path, pattern)
-                    elif entry.is_dir():
-                        _traverse(full_path, current_depth + 1)
-        except Exception as e:
-            files_info[current_path] = {"error": str(e)}
-
-    _traverse(dir_path, 0)
-    return files_info
-
-def compute_diff(prev_sample, curr_sample):
-    """
-    Compute differences between previous and current samples.
-
-    Returns a dict with keys:
-      - "created": files present in current sample but not in previous.
-      - "deleted": files present in previous sample but missing in current.
-      - "modified": files present in both but with differences.
-    For modified files, if 'last_modified' changed, the delta is computed.
-
-    Args:
-        prev_sample (dict): Previous sample data.
-        curr_sample (dict): Current sample data.
-
-    Returns:
-        dict: Diff results.
-    """
-    diff = {"created": {}, "deleted": {}, "modified": {}}
-    prev_files = set(prev_sample.keys()) if prev_sample else set()
-    curr_files = set(curr_sample.keys())
-
-    # Files created:
-    for file in curr_files - prev_files:
-        diff["created"][file] = curr_sample[file]
-
-    # Files deleted:
-    for file in prev_files - curr_files:
-        diff["deleted"][file] = prev_sample[file]
-
-    # Files modified:
-    for file in prev_files & curr_files:
-        prev_info = prev_sample.get(file, {})
-        curr_info = curr_sample.get(file, {})
-        changes = {}
-        for key in ["size", "last_modified", "creation_time", "md5", "sha256", "pattern_found"]:
-            if prev_info.get(key) != curr_info.get(key):
-                # For timestamps, we show the delta.
-                if key == "last_modified" and prev_info.get(key) and curr_info.get(key):
-                    changes[key] = curr_info.get(key) - prev_info.get(key)
-                else:
-                    changes[key] = {"from": prev_info.get(key), "to": curr_info.get(key)}
-        if changes:
-            diff["modified"][file] = changes
-
-    # Remove empty categories
-    diff = {k: v for k, v in diff.items() if v}
-    return diff
-
-def compute_hashes(file_path):
-    """
-    Compute the MD5 and SHA256 hashes for a file.
-
-    Args:
-        file_path (str): Path to the file.
-
-    Returns:
-        tuple: (md5_hash, sha256_hash) as hexadecimal strings.
-    """
-    md5_hash = hashlib.md5()
-    sha256_hash = hashlib.sha256()
-    with open(file_path, "rb") as f:
-        for chunk in iter(lambda: f.read(4096), b""):
-            md5_hash.update(chunk)
-            sha256_hash.update(chunk)
-    return md5_hash.hexdigest(), sha256_hash.hexdigest()
-
-def collect_file_info(file_path, pattern=None):
-    """
-    Collect information for a given file.
-    """
-    info = {}
+def compute_file_md5(file_path, block_size=65536):
+    """Compute MD5 hash of a file."""
+    md5 = hashlib.md5()
     try:
-        stats = os.stat(file_path)
-        info['size'] = stats.st_size
-        info['owner'] = pwd.getpwuid(stats.st_uid).pw_name
-        info['group'] = grp.getgrgid(stats.st_gid).gr_name
-        info['last_modified'] = stats.st_mtime
-        info['creation_time'] = stats.st_ctime
-        md5, sha256 = compute_hashes(file_path)
-        info['md5'] = md5
-        info['sha256'] = sha256
+        with open(file_path, 'rb') as f:
+            for chunk in iter(lambda: f.read(block_size), b''):
+                md5.update(chunk)
+        return md5.hexdigest()
+    except Exception:
+        return None
 
-        if pattern:
-            info['pattern_found'] = False
-            with open(file_path, "r", errors="ignore") as f:
-                for line in f:
-                    if pattern in line:
-                        info['pattern_found'] = True
-                        break
-    except Exception as e:
-        info['error'] = str(e)
-    return info
+def compute_file_sha256(file_path, block_size=65536):
+    """Compute SHA256 hash of a file."""
+    sha256 = hashlib.sha256()
+    try:
+        with open(file_path, 'rb') as f:
+            for chunk in iter(lambda: f.read(block_size), b''):
+                sha256.update(chunk)
+        return sha256.hexdigest()
+    except Exception:
+        return None
 
-def collect_dir_info(dir_path, max_depth=None):
+def collect_sample(watch_group, log_dir):
     """
-    Collect aggregated information for a directory (without per‑file details).
+    Collect sample data for the watch group.
+    Returns a tuple: (sample dict, sample_epoch)
     """
-    info = {
-        'file_count': 0,
-        'directory_count': 0,
-        'files': [],
-        'directories': []
-    }
+    sample = {}
+    sample_epoch = int(time.time())
+    watch_items = watch_group.get("watch_items", [])
+    pattern = watch_group.get("pattern")  # Optional string to search within files.
+    max_depth = watch_group.get("max_depth", 1)
 
-    def _traverse(current_path, current_depth):
-        if max_depth is not None and current_depth > max_depth:
-            return
-        try:
-            with os.scandir(current_path) as it:
-                for entry in it:
-                    if entry.is_file():
-                        info['file_count'] += 1
-                        info['files'].append(entry.path)
-                    elif entry.is_dir():
-                        info['directory_count'] += 1
-                        info['directories'].append(entry.path)
-                        _traverse(entry.path, current_depth + 1)
-        except Exception as e:
-            info.setdefault('errors', []).append({current_path: str(e)})
-    _traverse(dir_path, 0)
-    return info
+    def scan_path(path, current_depth):
+        if os.path.isfile(path):
+            metrics = {}
+            try:
+                stat = os.stat(path)
+                metrics["size"] = stat.st_size
+                metrics["last_modified"] = stat.st_mtime
+                metrics["creation_time"] = stat.st_ctime
+                metrics["md5"] = compute_file_md5(path)
+                metrics["sha256"] = compute_file_sha256(path)
+                if pattern:
+                    with open(path, "r", errors="ignore") as f:
+                        content = f.read()
+                    metrics["pattern_found"] = pattern in content
+                else:
+                    metrics["pattern_found"] = False
+                sample[path] = metrics
+            except Exception as e:
+                logging.error(f"Error collecting sample for {path}: {e}")
+        elif os.path.isdir(path) and current_depth <= max_depth:
+            try:
+                for entry in os.listdir(path):
+                    full_path = os.path.join(path, entry)
+                    scan_path(full_path, current_depth + 1)
+            except Exception as e:
+                logging.error(f"Error scanning directory {path}: {e}")
+
+    for item in watch_items:
+        if "*" in item or "?" in item:
+            import glob
+            for path in glob.glob(item):
+                scan_path(path, 1)
+        else:
+            scan_path(item, 1)
+
+    return sample, sample_epoch
 
 class Monitor:
-    """
-    Monitor class to watch directories/files based on a given configuration.
-    """
     def __init__(self, watch_group, db_path, log_dir, log_level="INFO"):
-        """
-        Initialize the Monitor.
-        """
         self.watch_group = watch_group
         self.db_path = db_path
-        self.sample_rate = max(watch_group.get('sample_rate', 60), 60)
-        self.max_samples = watch_group.get('max_samples', 5)
-        self.max_depth = watch_group.get('max_depth', None)
-        self.pattern = watch_group.get('pattern', None)
-        self.explode_directories = watch_group.get("explode_directories", False)
-        self.watch_items = watch_group.get('watch_items', [])
-        self.running = False
-        # Set up a logger for this watch group
-        log_filename = f"{self.watch_group.get('name', 'Unnamed').replace(' ', '_')}.log"
-        numeric_level = getattr(logging, log_level.upper(), logging.INFO)
-        self.logger = logger.setup_logger(self.watch_group.get('name', 'Unnamed'), log_dir, log_filename, level=numeric_level)
+        self.log_dir = log_dir
+        self.log_level = log_level
+        self.logger = self.setup_logger(log_level)
+        self._stop = False
 
-    def take_sample(self):
-        """
-        Take a single sample for all watch items.
-        """
-        sample = {}
-        for item in self.watch_items:
-            resolved_paths = glob.glob(item)
-            if not resolved_paths:
-                sample[item] = {'error': 'No matching file or directory found'}
-            for path in resolved_paths:
-                if os.path.isfile(path):
-                    sample[path] = collect_file_info(path, self.pattern)
-                elif os.path.isdir(path):
-                    if self.explode_directories:
-                        # Use per‑file granularity
-                        dir_files = collect_dir_files_info(path, self.max_depth, self.pattern)
-                        sample.update(dir_files)
-                    else:
-                        sample[path] = collect_dir_info(path, self.max_depth)
-                else:
-                    sample[path] = {'error': 'Not a file or directory'}
-        return sample
-
-    def evaluate_rules(self, sample, diff_result):
-        """
-        Evaluate rules defined in the watch group against the collected sample.
-        The evaluation context includes the current sample, previous sample differences,
-        and helper functions so that rules can compare against historical data.
-
-        Returns:
-            list: A list of triggered event dictionaries with extra metadata.
-        """
-        triggered = []
-        rules = self.watch_group.get('rules', [])
-        current_time = time.time()
-        eval_context = {
-            "data": sample,
-            "diff": diff_result,
-            "now": current_time,
-            "min": min,
-            "max": max,
-            "sum": sum,
-            "len": len,
-            "aggregate": aggregate_metric,
-            "get_previous_metric": lambda pattern, metric: get_previous_metric(
-                self.db_path,
-                self.watch_group.get('name', 'Unnamed'),
-                pattern,
-                metric
-            ),
-            "compute_diff": compute_diff
-        }
-        for rule in rules:
-            condition = rule.get('condition')
-            event_name = rule.get('name', 'Unnamed Event')
-            try:
-                self.logger.debug(f"Evaluating rule '{event_name}': now={current_time}, "
-                                  f"min_last_modified={aggregate_metric(sample, '*', 'last_modified', min)}")
-                condition_result = eval(condition, {"__builtins__": {}}, eval_context)
-                self.logger.debug(f"Condition '{condition}' evaluated to {condition_result}")
-                if condition and condition_result:
-                    triggered.append({"rule": rule, "diff": diff_result})
-
-            except Exception as e:
-                self.logger.error(f"Error evaluating rule '{event_name}': {e}")
-        return triggered
+    def setup_logger(self, log_level):
+        from eventwatcher import logger as event_logger
+        # Create a file name for the watch group log (spaces replaced with underscores).
+        file_name = f"{self.watch_group.get('name', 'Unnamed').replace(' ', '_')}.log"
+        return event_logger.setup_logger(
+            f"Monitor-{self.watch_group.get('name', 'Unnamed')}",
+            self.log_dir,
+            file_name,
+            level=getattr(logging, log_level.upper(), logging.INFO),
+            console=True
+        )
 
     def run_once(self):
-        """
-        Perform one monitoring cycle:
-          - Retrieve the previous sample.
-          - Collect the current sample.
-          - Compute the diff.
-          - Evaluate rules with access to the diff.
-          - Log the sample and triggered events.
-          - Store the sample and each triggered event with structured metadata.
+        self.logger.info("Starting monitoring cycle.")
+        sample, sample_epoch = collect_sample(self.watch_group, self.log_dir)
+        watch_group_name = self.watch_group.get("name", "Unnamed")
 
-        Returns:
-            tuple: (sample, list_of_triggered_events)
-        """
-        watch_group_name = self.watch_group.get('name', 'Unnamed')
-        prev_sample, _ = db.get_last_sample(self.db_path, watch_group_name)
-        current_sample = self.take_sample()
-        diff_result = compute_diff(prev_sample, current_sample) if prev_sample else {}
-        events = self.evaluate_rules(current_sample, diff_result)
-        self.logger.info(f"Sample: {current_sample}")
-        if events:
-            self.logger.info(f"Triggered events: {events}")
-        else:
-            self.logger.info("No events triggered.")
+        # Insert per-file records into the samples table.
+        for file_path, file_data in sample.items():
+            db.insert_sample_record(self.db_path, watch_group_name, sample_epoch, file_path, file_data)
 
-        # Store the full JSON sample in the samples table.
-        db.insert_sample(self.db_path, watch_group_name, current_sample)
+        now = int(time.time())
+        context = {
+            "data": sample,
+            "now": now,
+            "aggregate": rule_helpers.aggregate_metric,
+        }
 
-        # Store exploded sample entries for each file (if available).
-        sample_epoch = int(time.time())
-        for file_path, file_data in current_sample.items():
-            if isinstance(file_data, dict) and "error" not in file_data:
-                db.insert_exploded_sample(
-                    self.db_path,
-                    watch_group_name,
-                    sample_epoch,
-                    file_path,
-                    file_data
-                )
+        triggered = rules.evaluate_rules(self.watch_group.get("rules", []), context)
+        deduped_events = []
 
-        # Process and store events with enhanced metadata.
-        for event in events:
-            rule = event["rule"]
-            # Determine event type from rule config or from diff analysis.
-            event_type = rule.get("event_type")
-            if not event_type:
-                if diff_result.get("created"):
-                    event_type = "created"
-                elif diff_result.get("deleted"):
-                    event_type = "deleted"
-                elif diff_result.get("modified"):
-                    event_type = "modified"
-                else:
-                    event_type = "pattern_match"
-            severity = rule.get("severity", "INFO")
-            affected_files = []
-            timestamp_diff = {}
-            if diff_result:
-                for change_type in ["created", "deleted", "modified"]:
-                    if change_type in diff_result:
-                        for file, diff_values in diff_result[change_type].items():
-                            affected_files.append(file)
-                            if change_type == "modified" and "last_modified" in diff_values:
-                                timestamp_diff[file] = diff_values["last_modified"]
-            # Insert the event with all structured metadata.
-            db.insert_event(
-                self.db_path,
-                watch_group_name,
-                rule.get("name", "Unnamed Event"),
-                current_sample,
-                event_type,
-                severity,
-                affected_files,
-                timestamp_diff
-            )
-        return current_sample, events
+        for event in triggered:
+            rule_name = event.get("name")
+            event_type = event.get("event_type")
+            severity = event.get("severity")
+            affected_files = event.get("affected_files", [])
+            deduped_files = []
+            for file_path in affected_files:
+                prev_event = db.get_last_event_for_rule(self.db_path, watch_group_name, rule_name, file_path)
+                if prev_event:
+                    prev_sample = db.get_sample_record(self.db_path, watch_group_name, prev_event["sample_epoch"], file_path)
+                    current_metrics = sample.get(file_path, {})
+                    if prev_sample:
+                        if (prev_sample.get("md5") == current_metrics.get("md5") and
+                            prev_sample.get("last_modified") == current_metrics.get("last_modified")):
+                            self.logger.info(f"Skipping duplicate event for {file_path} under rule '{rule_name}'.")
+                            continue
+                deduped_files.append(file_path)
+            if deduped_files:
+                db.insert_event(self.db_path, watch_group_name, rule_name, sample_epoch,
+                                event_type=event_type, severity=severity, affected_files=deduped_files)
+                deduped_events.append({
+                    "rule": rule_name,
+                    "event_type": event_type,
+                    "severity": severity,
+                    "affected_files": deduped_files,
+                    "sample_epoch": sample_epoch
+                })
+
+        self.logger.info("Monitoring cycle completed.")
+        return sample, deduped_events
 
     def run(self):
-        """
-        Run the monitoring loop indefinitely based on the sample rate.
-        """
-        self.running = True
-        self.logger.info(f"Starting monitor for group '{self.watch_group.get('name', 'Unnamed')}' with sample rate {self.sample_rate} seconds.")
-        while self.running:
+        while not self._stop:
             self.run_once()
-            time.sleep(self.sample_rate)
+            sample_rate = self.watch_group.get("sample_rate", 60)
+            time.sleep(sample_rate)
 
     def stop(self):
-        """
-        Stop the monitoring loop.
-        """
-        self.running = False
-        self.logger.info(f"Stopping monitor for group '{self.watch_group.get('name', 'Unnamed')}'.")
+        self._stop = True

--- a/eventwatcher/rules.py
+++ b/eventwatcher/rules.py
@@ -1,38 +1,90 @@
-def evaluate_rule(rule, sample):
-    """
-    Evaluate a single rule against the sample.
+"""
+Rules module for EventWatcher.
 
-    Args:
-        rule (dict): Rule with 'name' and 'condition'.
-        sample (dict): Collected sample data.
+This module provides functions for evaluating rule conditions against a given context.
+Each rule may define a condition (a Python expression) that uses helper functions and
+variables from the context (such as `data`, `now`, and `aggregate`).
+
+Rules may also define optional fields:
+  - event_type: the type of event (e.g., "modified", "created", etc.)
+  - severity: the severity level (e.g., "WARNING", "CRITICAL", etc.)
+  - affected_files_expr (optional): a Python expression to determine which files are affected.
+"""
+
+def evaluate_rule(rule, context):
+    """
+    Evaluate a single rule against the given context.
+
+    The context should include:
+      - data: the current sample data (a dict mapping file paths to their metrics)
+      - now: current epoch time
+      - aggregate: a helper function for aggregating metrics, e.g., aggregate(data, '*.test', 'last_modified', min)
+
+    Optionally, the rule can define 'affected_files_expr', which when evaluated returns a list of affected files.
 
     Returns:
-        bool: True if the rule condition is met.
-
-    Raises:
-        ValueError: If there is an error evaluating the rule.
+      (triggered: bool, affected_files: list)
     """
     condition = rule.get('condition')
     if not condition:
-        return False
+        return False, []
+
+    # Build a local context from the provided context.
+    # This context is available to the eval() call.
+    local_context = context.copy()
+    # Pre-populate an empty list for affected_files in case the condition uses it.
+    local_context['affected_files'] = []
+
+    # Define a set of safe built-in functions for use in rule expressions.
+    safe_builtins = {
+        'min': min,
+        'max': max,
+        'any': any,
+        'all': all,
+        'sum': sum,
+        'len': len,
+    }
+
     try:
-        return eval(condition, {"__builtins__": {}}, {"data": sample})
+        # Evaluate the condition with our safe builtins.
+        triggered = eval(condition, {"__builtins__": safe_builtins}, local_context)
     except Exception as e:
         raise ValueError(f"Error evaluating rule '{rule.get('name', 'Unnamed')}': {e}")
 
-def evaluate_rules(rules, sample):
-    """
-    Evaluate a list of rules against the sample.
+    # Determine which files are affected.
+    affected_files = []
+    if 'affected_files_expr' in rule:
+        try:
+            affected_files = eval(rule['affected_files_expr'], {"__builtins__": safe_builtins}, local_context)
+        except Exception as e:
+            raise ValueError(f"Error evaluating affected_files_expr for rule '{rule.get('name', 'Unnamed')}': {e}")
+    else:
+        # If no affected_files_expr is provided and the rule is triggered,
+        # assume all files in the sample are affected.
+        if triggered:
+            affected_files = list(local_context.get("data", {}).keys())
 
-    Args:
-        rules (list): List of rule dictionaries.
-        sample (dict): Collected sample data.
+    return triggered, affected_files
 
-    Returns:
-        list: Names of triggered events.
+def evaluate_rules(rules, context):
     """
-    triggered = []
+    Evaluate a list of rules against the given context.
+
+    Returns a list of dicts for triggered events. Each dict contains:
+      - name: the rule's name
+      - event_type: the rule-defined event type (if any)
+      - severity: the rule-defined severity (if any)
+      - affected_files: list of file paths that triggered the event
+    """
+    triggered_events = []
     for rule in rules:
-        if evaluate_rule(rule, sample):
-            triggered.append(rule.get('name', 'Unnamed Event'))
-    return triggered
+        triggered, affected_files = evaluate_rule(rule, context)
+        if triggered and affected_files:
+            event_record = {
+                "name": rule.get("name", "Unnamed Event"),
+                "event_type": rule.get("event_type"),
+                "severity": rule.get("severity"),
+                "affected_files": affected_files
+            }
+            triggered_events.append(event_record)
+    return triggered_events

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(
         "pyyaml",
         "python-daemon",
         "rich",
-        "tabulate"
+        "tabulate",
+        "psutil"
     ],
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="eventwatcher",
-    version="0.1.0",
+    version="0.2.0",
     description="A file/directory event monitoring tool with daemon support",
     author="Araray Velho",
     packages=find_packages(),


### PR DESCRIPTION
In Monitor.run_once(), the rules are now skipped if no previous sample exists, and raw JSON sample is logged in DEBUG mode.

Events are now inserted on a per-file basis (each file change produces a separate event).

Added a new helper in db.py to detect previous samples.

In daemon mode, a periodic status logger logs process info (PID, CPU, memory, threads, start time, and watch group info) to daemon.log using psutil.

Extended CLI commands:

    - status: shows detailed process and watch group information (using rich table) and logs to daemon.log.
    - show-events: replaces show-db and supports various output formats (tabulate, json, csv, raw).
    - query: allows execution of arbitrary SQL queries against the database.
    - info: shows available tables/columns and lists available rule helper functions.